### PR TITLE
Fix icon install location, remove conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,16 @@
 PREFIX ?= /usr/local
 BUILDDIR = build
-ICONDIR = $(PREFIX)/share/icons
+ICONDIR = $(PREFIX)/share/pixmaps
 APPS = office word excel onenote outlook powerpoint skype
 
 all: build
 
 $(APPS):
 	mkdir -p $(BUILDDIR)/$@
-	sed -e "s|@APPNAMELOWER@|\L$@|" \
-	    -e "s|@APPNAME@|\u$@|" launcher.desktop.in > $(BUILDDIR)/$@/$@.desktop
+	sed -e "s|@APPNAME@|\u$@|" \
+	    -e "s|@APPNAMELOWER@|\L$@|" \
+	    -e "s|@CATEGORIES@|Office|" launcher.desktop.in > $(BUILDDIR)/$@/$@.desktop
 	sed -e "s|@ICON@|$(ICONDIR)/ms-$@.png|" settings.json.in > $(BUILDDIR)/$@/settings.json
-	if [[ "$@" == "skype" ]]; then \
-	    sed -i -e "s|@CATEGORIES@|Network|" $(BUILDDIR)/$@/$@.desktop ; \
-	else \
-	    sed -i -e "s|@CATEGORIES@|Office|" $(BUILDDIR)/$@/$@.desktop ; \
-	fi
 
 build: $(APPS)
 	sed -i "s|@URL@|https://www.office.com/login?es=Click\&ru=%2F|" $(BUILDDIR)/office/settings.json
@@ -24,6 +20,7 @@ build: $(APPS)
 	sed -i "s|@URL@|https://outlook.live.com/owa|" $(BUILDDIR)/outlook/settings.json
 	sed -i "s|@URL@|https://office.live.com/start/PowerPoint.aspx|" $(BUILDDIR)/powerpoint/settings.json
 	sed -i "s|@URL@|https://web.skype.com|" $(BUILDDIR)/skype/settings.json
+	sed -i "s|Categories=Office|Categories=Network|" $(BUILDDIR)/skype/skype.desktop
 
 install: build
 	install -dm755 $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/share/ms-office


### PR DESCRIPTION
This switches the icon directory installation location to /usr/share/pixmaps which is more compliant with https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#directory_layout .

It also removes the conditional which is checked for each application where it will only ever succeed for one; this specific change can be accomplished in the "customisation" section after the desktop launcher has been created.